### PR TITLE
Fix serverless.yml python runtime

### DIFF
--- a/deploy/serverless.yml
+++ b/deploy/serverless.yml
@@ -237,7 +237,7 @@ Resources:
                 
       Timeout: 30
       # python 3.7 includes cfn-response module
-      Runtime: python3.7
+      Runtime: python3.12
       InlineCode: |
         import logging
         import cfnresponse


### PR DESCRIPTION
Changed the Python Runtime from 3.7 to 3.12, as python3.7 is no longer supported for Lambda Functions.

*Issue #, if available:*

*Description of changes:* Changed the Python Runtime from 3.7 to 3.12, as python3.7 is no longer supported for Lambda Functions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
